### PR TITLE
feat: add dedicated activate/deactivate endpoints for servers (#9)

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1791,6 +1791,72 @@ async def toggle_server_status(
         raise HTTPException(status_code=400, detail=str(e))
 
 
+@server_router.post("/{server_id}/activate", response_model=ServerRead)
+@require_permission("servers.update")
+async def activate_server(
+    server_id: str,
+    db: Session = Depends(get_db),
+    user=Depends(get_current_user_with_permissions),
+) -> ServerRead:
+    """
+    Activates a server by its ID.
+
+    Args:
+        server_id (str): The ID of the server to activate.
+        db (Session): The database session used to interact with the data store.
+        user (str): The authenticated user making the request.
+
+    Returns:
+        ServerRead: The server object after activation.
+
+    Raises:
+        HTTPException: If the server is not found or there is an error.
+    """
+    try:
+        user_email = user.get("email") if isinstance(user, dict) else str(user)
+        logger.debug(f"User {user} is activating server with ID {server_id}")
+        return await server_service.toggle_server_status(db, server_id, True, user_email=user_email)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    except ServerNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except ServerError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@server_router.post("/{server_id}/deactivate", response_model=ServerRead)
+@require_permission("servers.update")
+async def deactivate_server(
+    server_id: str,
+    db: Session = Depends(get_db),
+    user=Depends(get_current_user_with_permissions),
+) -> ServerRead:
+    """
+    Deactivates a server by its ID.
+
+    Args:
+        server_id (str): The ID of the server to deactivate.
+        db (Session): The database session used to interact with the data store.
+        user (str): The authenticated user making the request.
+
+    Returns:
+        ServerRead: The server object after deactivation.
+
+    Raises:
+        HTTPException: If the server is not found or there is an error.
+    """
+    try:
+        user_email = user.get("email") if isinstance(user, dict) else str(user)
+        logger.debug(f"User {user} is deactivating server with ID {server_id}")
+        return await server_service.toggle_server_status(db, server_id, False, user_email=user_email)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    except ServerNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except ServerError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
 @server_router.delete("/{server_id}", response_model=Dict[str, str])
 @require_permission("servers.delete")
 async def delete_server(server_id: str, db: Session = Depends(get_db), user=Depends(get_current_user_with_permissions)) -> Dict[str, str]:


### PR DESCRIPTION
Fixes #9

## Problem
Virtual servers used a single toggle endpoint with a boolean parameter, which created confusion and potential errors when activating vs deactivating servers.

## Changes
- Added dedicated activate and deactivate endpoints for servers
- Follows the same pattern as user activate/deactivate endpoints
- Kept existing toggle endpoint for backward compatibility

## Benefits
- Explicit API actions with no confusion between activate vs deactivate
- Clearer intent where endpoint name matches the intended action
- Consistent with existing user endpoints in the codebase
- Reduced error potential by eliminating boolean parameters

## API Endpoints Added
- POST /servers/{server_id}/activate - Activates the specified server
- POST /servers/{server_id}/deactivate - Deactivates the specified server

Both endpoints use the same underlying server_service.toggle_server_status() function with appropriate boolean values.