### PR TITLE
fix: align OAuth refresh auth method with DCR and add refresh_token grant

### DIFF
--- a/mcp-catalog.yml
+++ b/mcp-catalog.yml
@@ -720,6 +720,29 @@ catalog_servers:
     documentation_url: "https://fireflies.ai/blog/model-context-protocol"
     tools: ["fireflies_search", "fireflies_get_transcripts", "fireflies_get_transcript", "fireflies_fetch", "fireflies_get_summary", "fireflies_get_user", "fireflies_get_usergroups", "fireflies_get_user_contacts"]
 
+  - id: read-ai
+    name: "Read AI"
+    category: "Productivity"
+    url: "https://api.read.ai/mcp"
+    auth_type: "OAuth2.1"
+    provider: "Read AI"
+    description: "Read AI's MCP server gives AI assistants access to meeting data including transcripts, summaries, and action items. Agents can list sessions, retrieve full transcripts, and query meeting insights without manual context-switching."
+    requires_api_key: false
+    tags: ["meetings", "transcription", "ai", "productivity"]
+    logo_url: "https://img.logo.dev/read.ai?token=pk_IQgnPY69T4mLXixm3ohN9A"
+    documentation_url: "https://support.read.ai/hc/en-us/articles/49381158409491-MCP-Server"
+    tools: ["list_meetings", "get_meeting_by_id"]
+    oauth_config:
+      authorize_url: "https://authn.read.ai/oauth2/auth"
+      token_url: "https://authn.read.ai/oauth2/token"
+      scopes: ["openid", "profile", "email", "offline_access", "mcp:execute", "meeting:read"]
+      supports_dcr: true
+      registration_url: "https://api.read.ai/oauth/register"
+      setup_guide: |
+        No external OAuth app setup required. This server supports Dynamic Client
+        Registration (RFC 7591). MCP clients register automatically. Users are
+        redirected to Read AI to authorize via their Read AI account.
+
   - id: listenetic
     name: "Listenetic"
     category: "Productivity"

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -122,6 +122,8 @@ async def initiate_oauth_flow(
                     oauth_config["client_id"] = registered_client.client_id
                     if decrypted_secret:
                         oauth_config["client_secret"] = decrypted_secret
+                    if registered_client.token_endpoint_auth_method:
+                        oauth_config["token_endpoint_auth_method"] = registered_client.token_endpoint_auth_method
 
                     # Discover AS metadata to get authorization/token endpoints if not already set
                     # Note: OAuthManager expects 'authorization_url' and 'token_url', not 'authorization_endpoint'/'token_endpoint'
@@ -187,6 +189,8 @@ async def initiate_oauth_flow(
                     oauth_config["client_id"] = registered_client.client_id
                     if decrypted_secret:
                         oauth_config["client_secret"] = decrypted_secret
+                    if registered_client.token_endpoint_auth_method:
+                        oauth_config["token_endpoint_auth_method"] = registered_client.token_endpoint_auth_method
 
                     # Update gateway's oauth_config and auth_type in database for future use
                     gateway.oauth_config = oauth_config
@@ -771,15 +775,17 @@ async def initiate_oauth_json(gateway_id: str, current_user: EmailUserResponse =
                     decrypted_secret = None
                     if registered_client.client_secret_encrypted:
                         # First-Party
-                        from mcpgateway.utils.oauth_encryption import get_oauth_encryption
+                        from mcpgateway.services.encryption_service import get_encryption_service
 
-                        encryption = get_oauth_encryption(settings.auth_encryption_secret)
+                        encryption = get_encryption_service(settings.auth_encryption_secret)
                         decrypted_secret = encryption.decrypt_secret(registered_client.client_secret_encrypted)
 
                     # Update oauth_config with registered credentials
                     oauth_config["client_id"] = registered_client.client_id
                     if decrypted_secret:
                         oauth_config["client_secret"] = decrypted_secret
+                    if registered_client.token_endpoint_auth_method:
+                        oauth_config["token_endpoint_auth_method"] = registered_client.token_endpoint_auth_method
 
                     # Discover AS metadata to get authorization/token endpoints
                     if not oauth_config.get("authorization_url") or not oauth_config.get("token_url"):
@@ -834,15 +840,17 @@ async def initiate_oauth_json(gateway_id: str, current_user: EmailUserResponse =
                     decrypted_secret = None
                     if registered_client.client_secret_encrypted:
                         # First-Party
-                        from mcpgateway.utils.oauth_encryption import get_oauth_encryption
+                        from mcpgateway.services.encryption_service import get_encryption_service
 
-                        encryption = get_oauth_encryption(settings.auth_encryption_secret)
+                        encryption = get_encryption_service(settings.auth_encryption_secret)
                         decrypted_secret = encryption.decrypt_secret(registered_client.client_secret_encrypted)
 
                     # Update oauth_config with registered credentials
                     oauth_config["client_id"] = registered_client.client_id
                     if decrypted_secret:
                         oauth_config["client_secret"] = decrypted_secret
+                    if registered_client.token_endpoint_auth_method:
+                        oauth_config["token_endpoint_auth_method"] = registered_client.token_endpoint_auth_method
 
                     # Update gateway's oauth_config and auth_type in database
                     gateway.oauth_config = oauth_config

--- a/mcpgateway/services/dcr_service.py
+++ b/mcpgateway/services/dcr_service.py
@@ -147,7 +147,7 @@ class DcrService:
         registration_request = {
             "client_name": client_name,
             "redirect_uris": [redirect_uri],
-            "grant_types": ["authorization_code"],
+            "grant_types": ["authorization_code", "refresh_token"],
             "response_types": ["code"],
             "token_endpoint_auth_method": self.settings.dcr_token_endpoint_auth_method,
             "scope": " ".join(scopes),
@@ -277,7 +277,7 @@ class DcrService:
         registration_request = {
             "client_name": client_name,
             "redirect_uris": [redirect_uri],
-            "grant_types": ["authorization_code"],
+            "grant_types": ["authorization_code", "refresh_token"],
             "response_types": ["code"],
             "token_endpoint_auth_method": self.settings.dcr_token_endpoint_auth_method,
             "scope": " ".join(scopes),

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -1174,18 +1174,26 @@ class OAuthManager:
         token_data = {
             "grant_type": "refresh_token",
             "refresh_token": refresh_token,
-            "client_id": client_id,
         }
 
-        # Add client_secret if available (some providers require it)
-        if client_secret:
-            token_data["client_secret"] = client_secret
+        # Determine token endpoint auth method (same logic as _exchange_code_for_tokens)
+        token_endpoint_auth_method = credentials.get("token_endpoint_auth_method", "client_secret_post")
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        if token_endpoint_auth_method == "client_secret_basic" and client_secret:
+            auth_string = f"{client_id}:{client_secret}"
+            auth_bytes = base64.b64encode(auth_string.encode()).decode()
+            headers["Authorization"] = f"Basic {auth_bytes}"
+        else:
+            token_data["client_id"] = client_id
+            if client_secret:
+                token_data["client_secret"] = client_secret
 
         # Attempt token refresh with retries
         for attempt in range(self.max_retries):
             try:
                 async with aiohttp.ClientSession() as session:
-                    async with session.post(token_url, data=token_data, timeout=aiohttp.ClientTimeout(total=self.request_timeout)) as response:
+                    async with session.post(token_url, data=token_data, headers=headers, timeout=aiohttp.ClientTimeout(total=self.request_timeout)) as response:
                         if response.status == 200:
                             token_response = await response.json()
 

--- a/tests/unit/mcpgateway/services/test_dcr_service.py
+++ b/tests/unit/mcpgateway/services/test_dcr_service.py
@@ -295,7 +295,7 @@ class TestRegisterClient:
 
             assert request_json["client_name"] == "MCP Gateway (Test Gateway)"
             assert request_json["redirect_uris"] == ["http://localhost:4444/callback"]
-            assert request_json["grant_types"] == ["authorization_code"]
+            assert request_json["grant_types"] == ["authorization_code", "refresh_token"]
             assert request_json["response_types"] == ["code"]
             assert request_json["scope"] == "mcp:read"
 

--- a/tests/unit/mcpgateway/test_oauth_manager.py
+++ b/tests/unit/mcpgateway/test_oauth_manager.py
@@ -865,6 +865,7 @@ class TestOAuthManager:
 
             mock_response = MagicMock()
             mock_response.status = 400
+            mock_response.text = AsyncMock(return_value="Bad Request")
             mock_response.raise_for_status = MagicMock(side_effect=aiohttp.ClientResponseError(request_info=MagicMock(), history=(), status=400, message="Bad Request"))
             mock_response.__aenter__ = AsyncMock(return_value=mock_response)
             mock_response.__aexit__ = AsyncMock(return_value=None)


### PR DESCRIPTION
## Summary

- **Fix refresh token auth method**: `refresh_token()` now respects `token_endpoint_auth_method` (e.g. `client_secret_basic`) instead of always using `client_secret_post`, matching the logic already in `_exchange_code_for_tokens()`
- **Add `refresh_token` grant type to DCR**: Both `register_client()` and `register_client_direct()` now request `["authorization_code", "refresh_token"]` so the AS issues refresh tokens
- **Propagate `token_endpoint_auth_method`**: The auth method from DCR-registered clients is now passed through `oauth_config` to `OAuthManager` in all 4 flow paths (HTML + JSON, issuer-based + catalog)
- **Consolidate encryption imports**: Replace stale `oauth_encryption` imports with `encryption_service` in the JSON OAuth flow paths
- **Add Read AI to MCP catalog**: New catalog entry with OAuth 2.1 + DCR support
- **Fix test assertions**: Update mocks and assertions to match the production changes