### PR TITLE
fix: restrict CORS allow_headers to explicit list

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1081,7 +1081,16 @@ app.add_middleware(
     allow_origins=cors_origins,
     allow_credentials=settings.cors_allow_credentials,
     allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-    allow_headers=["*"],
+    allow_headers=[
+        "Content-Type",
+        "Authorization",
+        "X-Request-ID",
+        "X-API-Key",
+        "Accept",
+        "Origin",
+        "X-Requested-With",
+        "Mcp-Protocol-Version",
+    ],
     expose_headers=["Content-Length", "X-Request-ID"],
 )
 


### PR DESCRIPTION
## Summary

- Replaces the overly permissive `allow_headers=["*"]` in the CORS middleware configuration with an explicit allowlist of required headers
- When combined with `allow_credentials=True`, the wildcard allowed credential-bearing cross-origin requests with arbitrary headers, which is a security risk
- The new list permits only the headers the application actually needs: `Content-Type`, `Authorization`, `X-Request-ID`, `X-API-Key`, `Accept`, `Origin`, `X-Requested-With`, and `Mcp-Protocol-Version`

## Changes

- `mcpgateway/main.py`: Replaced `allow_headers=["*"]` with an explicit list of 8 required headers in the `CORSMiddleware` configuration