### PR TITLE
fix: restrict ProxyHeadersMiddleware to trusted hosts only

### DIFF
--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -353,6 +353,10 @@ class Settings(BaseSettings):
 
     # Security: Trusted Proxies for X-Forwarded-For / X-Real-IP
     trusted_proxies: List[str] = Field(default_factory=list, description="List of trusted proxy IP addresses/CIDRs for X-Forwarded-For (empty = don't trust forwarded headers)")
+    trusted_proxy_hosts: str = Field(
+        default="127.0.0.1,::1",
+        description="Comma-separated list of trusted proxy hosts/IPs. Use '*' only in development."
+    )
 
     # A2A (Agent-to-Agent) Feature Flags
     mcpgateway_a2a_enabled: bool = True

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1128,8 +1128,9 @@ if plugin_manager:
 # Add custom DocsAuthMiddleware
 app.add_middleware(DocsAuthMiddleware)
 
-# Trust all proxies (or lock down with a list of host patterns)
-app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
+# Trust only configured proxy hosts (default: localhost only)
+trusted = settings.trusted_proxy_hosts.split(",") if settings.trusted_proxy_hosts != "*" else "*"
+app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=trusted)
 
 # Add request logging middleware if enabled
 if settings.log_requests:


### PR DESCRIPTION
## Summary
- Add configurable `trusted_proxy_hosts` setting in `config.py` with a safe default of `127.0.0.1,::1` (localhost only)
- Replace hardcoded `trusted_hosts="*"` wildcard in `ProxyHeadersMiddleware` with the configurable setting
- Prevents IP spoofing via forged proxy headers from untrusted sources (F-07)

## Changes
- **`mcpgateway/config.py`**: Added `trusted_proxy_hosts` field with safe default near existing proxy settings
- **`mcpgateway/main.py`**: Updated `ProxyHeadersMiddleware` to parse the configured trusted hosts instead of trusting all sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)