### PR TITLE
fix: require authentication on reverse proxy SSE endpoint

### DIFF
--- a/mcpgateway/routers/reverse_proxy.py
+++ b/mcpgateway/routers/reverse_proxy.py
@@ -323,12 +323,14 @@ async def send_request_to_session(
 async def sse_endpoint(
     session_id: str,
     request: Request,
+    _: str | dict = Depends(require_auth),
 ):
     """SSE endpoint for receiving messages from a reverse proxy session.
 
     Args:
         session_id: Session ID to subscribe to.
         request: HTTP request.
+        _: Authenticated user info (used for auth check).
 
     Returns:
         SSE stream.


### PR DESCRIPTION
## Summary
- Add `Depends(require_auth)` to the `GET /reverse-proxy/sse/{session_id}` endpoint, which previously had **no authentication requirement**
- This is a HIGH severity security fix (F-05): unauthenticated attackers could access server sessions via the SSE endpoint
- The fix follows the exact same pattern already used by all other endpoints in the reverse proxy router (`/sessions`, `/sessions/{id}`, `/sessions/{id}/request`)

## Test plan
- [ ] Verify `GET /reverse-proxy/sse/{session_id}` returns 401/403 without valid credentials
- [ ] Verify `GET /reverse-proxy/sse/{session_id}` works correctly with valid Bearer token
- [ ] Verify other reverse proxy endpoints continue to work as expected