### PR TITLE
fix: enforce server-side session ID generation in WebSocket proxy

### DIFF
--- a/mcpgateway/routers/reverse_proxy.py
+++ b/mcpgateway/routers/reverse_proxy.py
@@ -163,8 +163,8 @@ async def websocket_endpoint(
         websocket: WebSocket connection.
         db: Database session.
     """
-    # Get session ID from headers or generate new one
-    session_id = websocket.headers.get("X-Session-ID", uuid.uuid4().hex)
+    # Always generate server-side session ID to prevent client-supplied session fixation
+    session_id = uuid.uuid4().hex
 
     # Check authentication before accepting the connection
     user = None


### PR DESCRIPTION
## Summary
- Removes acceptance of client-supplied session IDs via the X-Session-ID header in the reverse proxy WebSocket endpoint
- Session IDs are now always generated server-side using uuid4().hex, preventing session fixation attacks where clients could supply predictable or reused IDs

## Related Issue
Closes F-22 (Client-Supplied Session IDs Accepted)

## Changes
- mcpgateway/routers/reverse_proxy.py line 167: replaced websocket.headers.get("X-Session-ID", uuid.uuid4().hex) with uuid.uuid4().hex