### PR TITLE
fix: enforce token expiration by default

### DIFF
--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -194,7 +194,7 @@ class Settings(BaseSettings):
     auth_required: bool = True
     token_expiry: int = 10080  # minutes
 
-    require_token_expiration: bool = Field(default=False, description="Require all JWT tokens to have expiration claims")  # Default to flexible mode for backward compatibility
+    require_token_expiration: bool = Field(default=True, description="Require all JWT tokens to have expiration claims")
 
     # SSO Configuration
     sso_enabled: bool = Field(default=False, description="Enable Single Sign-On authentication")


### PR DESCRIPTION
## Summary
- Changed `require_token_expiration` default from `False` to `True` in `mcpgateway/config.py`
- JWT tokens without an `exp` claim will now be rejected by default, closing a security gap where tokens could remain valid indefinitely (F-15)

## Severity
MEDIUM - Tokens without expiration claims were accepted by default, allowing indefinite access if a token was leaked.