### PR TITLE
fix: add SSRF protection to federation peer discovery and forwarding

### DIFF
--- a/mcpgateway/federation/discovery.py
+++ b/mcpgateway/federation/discovery.py
@@ -233,6 +233,64 @@ class LocalDiscoveryService:
         return addresses or ["127.0.0.1"]
 
 
+def _is_safe_url(url: str) -> bool:
+    """Validate that a URL does not point to private/internal networks.
+
+    Checks the URL scheme, resolves the hostname to IP addresses, and blocks
+    any that resolve to private, loopback, link-local, or reserved ranges.
+    This prevents SSRF attacks via federation peer registration.
+
+    Args:
+        url (str): The URL to validate.
+
+    Returns:
+        bool: True if the URL is safe (points to a public address), False otherwise.
+
+    Examples:
+        >>> _is_safe_url("http://example.com")  # doctest: +SKIP
+        True
+        >>> _is_safe_url("http://169.254.169.254/latest/meta-data")
+        False
+        >>> _is_safe_url("http://127.0.0.1:6379")
+        False
+        >>> _is_safe_url("http://[::1]:8080")
+        False
+        >>> _is_safe_url("ftp://example.com")
+        False
+        >>> _is_safe_url("not-a-url")
+        False
+        >>> _is_safe_url("http://10.0.0.1:8080")
+        False
+        >>> _is_safe_url("http://192.168.1.1")
+        False
+        >>> _is_safe_url("http://172.16.0.1")
+        False
+    """
+    try:
+        parsed = urlparse(url)
+        if not parsed.scheme or not parsed.netloc:
+            return False
+        if parsed.scheme not in ("http", "https"):
+            return False
+        hostname = parsed.hostname
+        if not hostname:
+            return False
+        # Resolve hostname to IP and check all resolved addresses
+        try:
+            addr_info = socket.getaddrinfo(hostname, None)
+            for family, _, _, _, sockaddr in addr_info:
+                ip = ipaddress.ip_address(sockaddr[0])
+                if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+                    logger.warning(f"Blocked federation peer URL pointing to private/internal address: {url} -> {ip}")
+                    return False
+        except socket.gaierror:
+            logger.warning(f"Failed to resolve federation peer hostname: {hostname}")
+            return False
+        return True
+    except Exception:
+        return False
+
+
 class DiscoveryService(LocalDiscoveryService):
     """Service for automatic gateway discovery.
 
@@ -413,6 +471,11 @@ class DiscoveryService(LocalDiscoveryService):
                 return False
         except Exception:
             logger.warning(f"Failed to parse peer URL: {url}")
+            return False
+
+        # Block URLs pointing to private/internal IP ranges to prevent SSRF
+        if not _is_safe_url(url):
+            logger.warning(f"Rejected peer URL targeting private/internal network: {url}")
             return False
 
         # Skip if already known

--- a/mcpgateway/federation/forward.py
+++ b/mcpgateway/federation/forward.py
@@ -41,6 +41,7 @@ from mcpgateway.config import settings
 from mcpgateway.db import Gateway as DbGateway
 from mcpgateway.db import ServerMetric
 from mcpgateway.db import Tool as DbTool
+from mcpgateway.federation.discovery import _is_safe_url
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.utils.passthrough_headers import get_passthrough_headers
 
@@ -460,6 +461,10 @@ class ForwardingService:
         gateway = db.get(DbGateway, gateway_id)
         if not gateway or not gateway.enabled:
             raise ForwardingError(f"Gateway not found: {gateway_id}")
+
+        # Block requests to private/internal IP ranges to prevent SSRF
+        if not _is_safe_url(gateway.url):
+            raise ForwardingError(f"Gateway URL targets a private/internal network: {gateway.url}")
 
         try:
             # Check rate limits


### PR DESCRIPTION
## Summary
- Adds `_is_safe_url()` function in `discovery.py` that resolves hostnames to IP addresses and blocks private (`10.x`, `172.16.x`, `192.168.x`), loopback (`127.x`, `::1`), link-local (`169.254.x`), and reserved IP ranges
- Integrates the check into `add_peer()` in `discovery.py` to block SSRF at peer registration time
- Integrates the same check into `_forward_to_gateway()` in `forward.py` to block SSRF at request forwarding time
- Only allows `http` and `https` URL schemes

This prevents SSRF attacks where an attacker registers a federation peer pointing to internal services (e.g., `http://169.254.169.254/latest/meta-data` for cloud metadata, `http://127.0.0.1:6379` for local Redis).