### PR TITLE
fix: verify OAuth state HMAC signature in callback handlers

### DIFF
--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -13,6 +13,10 @@ This module handles OAuth 2.0 Authorization Code flow endpoints including:
 """
 
 # Standard
+import base64
+import hashlib
+import hmac
+import json
 import logging
 from typing import Any, Dict
 
@@ -273,20 +277,23 @@ async def oauth_callback(
 
         # Extract gateway_id from state parameter
         # Try new base64-encoded JSON format first
-        # Standard
-        import base64
-        import json
-
         try:
             # Expect state as base64url(payload || signature) where the last 32 bytes
-            # are the signature. Decode to bytes first so we can split payload vs sig.
+            # are the HMAC-SHA256 signature. Decode to bytes first so we can split.
             state_raw = base64.urlsafe_b64decode(state.encode())
             if len(state_raw) <= 32:
                 raise ValueError("State too short to contain payload and signature")
 
             # Split payload and signature. Signature is the last 32 bytes.
             payload_bytes = state_raw[:-32]
-            # signature_bytes = state_raw[-32:]
+            signature_bytes = state_raw[-32:]
+
+            # Verify HMAC signature before trusting any payload data
+            secret_key = settings.auth_encryption_secret.get_secret_value().encode() if settings.auth_encryption_secret else b"default-secret-key"
+            expected_sig = hmac.new(secret_key, payload_bytes, hashlib.sha256).digest()
+            if not hmac.compare_digest(signature_bytes, expected_sig):
+                logger.warning("OAuth callback received state with invalid HMAC signature")
+                return HTMLResponse(content="<h1>Invalid OAuth state signature</h1>", status_code=400)
 
             # Parse the JSON payload only (not including signature bytes)
             try:
@@ -301,7 +308,7 @@ async def oauth_callback(
             # Fallback to legacy format (gateway_id_random)
             logger.warning(f"Failed to decode state as JSON, trying legacy format: {e}")
             if "_" not in state:
-                return HTMLResponse(content="<h1>❌ Invalid state parameter</h1>", status_code=400)
+                return HTMLResponse(content="<h1>Invalid state parameter</h1>", status_code=400)
             gateway_id = state.split("_")[0]
 
         # Get gateway configuration

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -933,10 +933,6 @@ async def oauth_callback_json(code: str, state: str, db: Session = Depends(get_d
 
     try:
         # Extract gateway_id from state parameter
-        # Standard
-        import base64
-        import json
-
         try:
             # Decode state (base64url encoded JSON with HMAC signature)
             state_raw = base64.urlsafe_b64decode(state.encode())
@@ -945,6 +941,14 @@ async def oauth_callback_json(code: str, state: str, db: Session = Depends(get_d
 
             # Split payload and signature (last 32 bytes)
             payload_bytes = state_raw[:-32]
+            signature_bytes = state_raw[-32:]
+
+            # Verify HMAC signature before trusting any payload data
+            secret_key = settings.auth_encryption_secret.get_secret_value().encode() if settings.auth_encryption_secret else b"default-secret-key"
+            expected_sig = hmac.new(secret_key, payload_bytes, hashlib.sha256).digest()
+            if not hmac.compare_digest(signature_bytes, expected_sig):
+                logger.warning("OAuth JSON callback received state with invalid HMAC signature")
+                raise HTTPException(status_code=400, detail="Invalid OAuth state signature")
 
             try:
                 state_data = json.loads(payload_bytes.decode())

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -9,6 +9,10 @@ This module tests OAuth endpoints including authorization flow, callbacks, and s
 """
 
 # Standard
+import base64
+import hashlib
+import hmac as hmac_mod
+import json
 from unittest.mock import AsyncMock, Mock, patch
 
 # Third-Party
@@ -21,6 +25,16 @@ from sqlalchemy.orm import Session
 from mcpgateway.db import Gateway
 from mcpgateway.schemas import EmailUserResponse
 from mcpgateway.services.oauth_manager import OAuthError
+
+# Test secret matching the config default "my-test-salt"
+_TEST_SECRET = b"my-test-salt"
+
+
+def _make_signed_state(state_data: dict) -> str:
+    """Build a base64url-encoded state with a valid HMAC-SHA256 signature."""
+    payload = json.dumps(state_data).encode()
+    signature = hmac_mod.new(_TEST_SECRET, payload, hashlib.sha256).digest()
+    return base64.urlsafe_b64encode(payload + signature).decode()
 
 
 class TestOAuthRouter:
@@ -181,15 +195,9 @@ class TestOAuthRouter:
     @pytest.mark.asyncio
     async def test_oauth_callback_success(self, mock_db, mock_request, mock_gateway):
         """Test successful OAuth callback handling."""
-        # Standard
-        import base64
-        import json
-
-        # Setup state with new format (payload + 32-byte signature)
+        # Setup state with new format (payload + HMAC signature)
         state_data = {"gateway_id": "gateway123", "app_user_email": "test@example.com", "nonce": "abc123"}
-        payload = json.dumps(state_data).encode()
-        signature = b"x" * 32  # Mock 32-byte signature
-        state = base64.urlsafe_b64encode(payload + signature).decode()
+        state = _make_signed_state(state_data)
 
         mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
 
@@ -275,15 +283,9 @@ class TestOAuthRouter:
     @pytest.mark.asyncio
     async def test_oauth_callback_gateway_not_found(self, mock_db, mock_request):
         """Test OAuth callback when gateway is not found."""
-        # Standard
-        import base64
-        import json
-
         # Setup
         state_data = {"gateway_id": "nonexistent", "app_user_email": "test@example.com"}
-        payload = json.dumps(state_data).encode()
-        signature = b"x" * 32  # Mock 32-byte signature
-        state = base64.urlsafe_b64encode(payload + signature).decode()
+        state = _make_signed_state(state_data)
 
         mock_db.execute.return_value.scalar_one_or_none.return_value = None
 
@@ -301,15 +303,9 @@ class TestOAuthRouter:
     @pytest.mark.asyncio
     async def test_oauth_callback_no_oauth_config(self, mock_db, mock_request):
         """Test OAuth callback when gateway has no OAuth config."""
-        # Standard
-        import base64
-        import json
-
         # Setup
         state_data = {"gateway_id": "gateway123", "app_user_email": "test@example.com"}
-        payload = json.dumps(state_data).encode()
-        signature = b"x" * 32  # Mock 32-byte signature
-        state = base64.urlsafe_b64encode(payload + signature).decode()
+        state = _make_signed_state(state_data)
 
         mock_gateway = Mock(spec=Gateway)
         mock_gateway.id = "gateway123"
@@ -330,15 +326,9 @@ class TestOAuthRouter:
     @pytest.mark.asyncio
     async def test_oauth_callback_oauth_error(self, mock_db, mock_request, mock_gateway):
         """Test OAuth callback when OAuth manager throws OAuthError."""
-        # Standard
-        import base64
-        import json
-
         # Setup
         state_data = {"gateway_id": "gateway123", "app_user_email": "test@example.com"}
-        payload = json.dumps(state_data).encode()
-        signature = b"x" * 32  # Mock 32-byte signature
-        state = base64.urlsafe_b64encode(payload + signature).decode()
+        state = _make_signed_state(state_data)
 
         mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
 
@@ -551,15 +541,9 @@ class TestOAuthRouter:
     @pytest.mark.asyncio
     async def test_oauth_callback_json_success(self, mock_db, mock_gateway):
         """Test successful OAuth callback with JSON response."""
-        # Standard
-        import base64
-        import json
-
         # Setup
         state_data = {"gateway_id": "gateway123", "user_id": "test@example.com"}
-        payload = json.dumps(state_data).encode()
-        signature = b"0" * 32  # Mock signature
-        state_encoded = base64.urlsafe_b64encode(payload + signature).decode()
+        state_encoded = _make_signed_state(state_data)
 
         mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
 
@@ -603,15 +587,9 @@ class TestOAuthRouter:
     @pytest.mark.asyncio
     async def test_oauth_callback_json_gateway_not_found(self, mock_db):
         """Test JSON OAuth callback with non-existent gateway."""
-        # Standard
-        import base64
-        import json
-
         # Setup
         state_data = {"gateway_id": "nonexistent", "user_id": "test@example.com"}
-        payload = json.dumps(state_data).encode()
-        signature = b"0" * 32
-        state_encoded = base64.urlsafe_b64encode(payload + signature).decode()
+        state_encoded = _make_signed_state(state_data)
 
         mock_db.execute.return_value.scalar_one_or_none.return_value = None
 
@@ -628,15 +606,9 @@ class TestOAuthRouter:
     @pytest.mark.asyncio
     async def test_oauth_callback_json_oauth_error(self, mock_db, mock_gateway):
         """Test JSON OAuth callback when OAuth manager raises error."""
-        # Standard
-        import base64
-        import json
-
         # Setup
         state_data = {"gateway_id": "gateway123", "user_id": "test@example.com"}
-        payload = json.dumps(state_data).encode()
-        signature = b"0" * 32
-        state_encoded = base64.urlsafe_b64encode(payload + signature).decode()
+        state_encoded = _make_signed_state(state_data)
 
         mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
 


### PR DESCRIPTION
## Summary

- **Fixes F-06**: OAuth state parameter HMAC signature was never verified in callback handlers, defeating CSRF protection
- Both `/oauth/callback` (HTML) and `/oauth/api/callback` (JSON) endpoints extracted `gateway_id` from the state payload without checking the HMAC-SHA256 signature, even though `OAuthManager._generate_state()` properly signs the state
- An attacker could forge the state parameter to redirect token grants to arbitrary gateways

## Changes

- Added HMAC-SHA256 signature verification in both callback handlers **before** trusting any data from the state payload
- Uses `hmac.compare_digest()` for constant-time comparison to prevent timing side-channel attacks
- Uses the same `auth_encryption_secret` key that `OAuthManager` uses for state generation
- Moved `base64`, `json`, `hmac`, `hashlib` imports to module level (removed redundant inline imports)
- Returns HTTP 400 with clear error messages on signature mismatch