### PR TITLE
fix: filter sensitive env vars from Jinja2 plugin config templates

### DIFF
--- a/mcpgateway/plugins/framework/loader/config.py
+++ b/mcpgateway/plugins/framework/loader/config.py
@@ -10,6 +10,7 @@ This module loads configurations for plugins.
 
 # Standard
 import os
+from typing import Dict
 
 # Third-Party
 import jinja2
@@ -17,6 +18,38 @@ import yaml
 
 # First-Party
 from mcpgateway.plugins.framework.models import Config, PluginSettings
+
+_SENSITIVE_ENV_PREFIXES = (
+    "JWT_",
+    "DATABASE_",
+    "REDIS_",
+    "BASIC_AUTH_",
+    "OPENAI_",
+    "ANTHROPIC_",
+    "SSO_",
+    "OAUTH_",
+    "PLATFORM_ADMIN_",
+    "AUTH_ENCRYPTION_",
+    "POSTGRES_",
+    "MYSQL_",
+    "SECRET_",
+    "PRIVATE_KEY_",
+    "API_KEY",
+    "AWS_SECRET",
+    "AZURE_",
+    "GCP_",
+    "KEYCLOAK_",
+)
+
+
+def _get_safe_template_env() -> Dict[str, str]:
+    """Return filtered environment variables safe for Jinja2 template rendering.
+
+    Strips out any environment variable whose uppercased name starts with a
+    known sensitive prefix (e.g. JWT_, DATABASE_, SECRET_) to prevent
+    accidental exposure of credentials through plugin config templates.
+    """
+    return {k: v for k, v in os.environ.items() if not any(k.upper().startswith(prefix) for prefix in _SENSITIVE_ENV_PREFIXES)}
 
 
 class ConfigLoader:
@@ -77,7 +110,7 @@ class ConfigLoader:
                 template = file.read()
                 if use_jinja:
                     jinja_env = jinja2.Environment(loader=jinja2.BaseLoader(), autoescape=True)
-                    rendered_template = jinja_env.from_string(template).render(env=os.environ)
+                    rendered_template = jinja_env.from_string(template).render(env=_get_safe_template_env())
                 else:
                     rendered_template = template
                 config_data = yaml.safe_load(rendered_template) or {}


### PR DESCRIPTION
## Summary

- **Security fix (F-18):** Jinja2 plugin config templates previously received the full `os.environ`, allowing templates to access secrets like `JWT_SECRET_KEY`, `DATABASE_URL`, and API keys via `{{ env.VAR_NAME }}`.
- Added `_get_safe_template_env()` function that filters out environment variables matching known sensitive prefixes (JWT_, DATABASE_, SECRET_, API_KEY, REDIS_, OPENAI_, ANTHROPIC_, etc.) before passing them to the Jinja2 template renderer.
- This mirrors the environment filtering approach already applied to plugin subprocesses.

## Changes

**`mcpgateway/plugins/framework/loader/config.py`:**
- Added `_SENSITIVE_ENV_PREFIXES` tuple with 19 known sensitive prefix patterns
- Added `_get_safe_template_env()` helper that returns only non-sensitive env vars
- Changed `render(env=os.environ)` to `render(env=_get_safe_template_env())`