### PR TITLE
fix: add rate limiting to auth and token creation endpoints

### DIFF
--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -45,6 +45,7 @@ from mcpgateway.schemas import (
 from mcpgateway.services.email_auth_service import AuthenticationError, EmailAuthService, EmailValidationError, PasswordValidationError, UserExistsError
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.utils.create_jwt_token import create_jwt_token
+from mcpgateway.utils.rate_limit import auth_rate_limiter
 
 # Initialize logging
 logging_service = LoggingService()
@@ -207,6 +208,7 @@ async def login(login_request: EmailLoginRequest, request: Request, db: Session 
               "password": "secure_password"
             }
     """
+    auth_rate_limiter.check(request)
     auth_service = EmailAuthService(db)
     ip_address = get_client_ip(request)
     user_agent = get_user_agent(request)
@@ -254,6 +256,7 @@ async def register(registration_request: EmailRegistrationRequest, request: Requ
               "full_name": "New User"
             }
     """
+    auth_rate_limiter.check(request)
     auth_service = EmailAuthService(db)
     get_client_ip(request)
     get_user_agent(request)

--- a/mcpgateway/routers/tokens.py
+++ b/mcpgateway/routers/tokens.py
@@ -12,7 +12,7 @@ Provides comprehensive API token management with scoping, revocation, and analyt
 from typing import Optional
 
 # Third-Party
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
 # First-Party
@@ -28,6 +28,7 @@ from mcpgateway.schemas import (
     TokenUsageStatsResponse,
 )
 from mcpgateway.services.token_catalog_service import TokenCatalogService, TokenScope
+from mcpgateway.utils.rate_limit import token_rate_limiter
 
 router = APIRouter(prefix="/tokens", tags=["tokens"])
 
@@ -36,6 +37,7 @@ router = APIRouter(prefix="/tokens", tags=["tokens"])
 @require_permission("tokens.create")
 async def create_token(
     request: TokenCreateRequest,
+    http_request: Request,
     current_user=Depends(get_current_user_with_permissions),
     db: Session = Depends(get_db),
 ) -> TokenCreateResponse:
@@ -57,6 +59,7 @@ async def create_token(
         >>> asyncio.iscoroutinefunction(create_token)
         True
     """
+    token_rate_limiter.check(http_request)
     service = TokenCatalogService(db)
 
     # if not request.team_id:

--- a/mcpgateway/utils/rate_limit.py
+++ b/mcpgateway/utils/rate_limit.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+"""Simple in-memory rate limiter for authentication endpoints.
+
+Location: ./mcpgateway/utils/rate_limit.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Provides a lightweight token-bucket style rate limiter keyed by client IP
+to protect auth endpoints against brute-force and credential-stuffing attacks.
+
+Examples:
+    >>> limiter = RateLimiter(max_requests=5, window_seconds=60)
+    >>> isinstance(limiter, RateLimiter)
+    True
+"""
+
+import time
+from collections import defaultdict
+
+from fastapi import HTTPException, Request
+
+
+class RateLimiter:
+    """Token bucket rate limiter keyed by client IP.
+
+    Tracks request timestamps per client IP within a sliding time window
+    and raises HTTP 429 when the limit is exceeded.
+
+    Attributes:
+        max_requests: Maximum number of requests allowed per window.
+        window_seconds: Duration of the sliding window in seconds.
+
+    Examples:
+        >>> limiter = RateLimiter(max_requests=10, window_seconds=60)
+        >>> limiter.max_requests
+        10
+        >>> limiter.window_seconds
+        60
+    """
+
+    def __init__(self, max_requests: int = 10, window_seconds: int = 60):
+        self.max_requests = max_requests
+        self.window_seconds = window_seconds
+        self._requests: dict[str, list[float]] = defaultdict(list)
+
+    def _get_client_ip(self, request: Request) -> str:
+        """Extract client IP from the request, respecting X-Forwarded-For.
+
+        Args:
+            request: FastAPI request object.
+
+        Returns:
+            str: The client IP address.
+
+        Examples:
+            >>> limiter = RateLimiter()
+            >>> callable(limiter._get_client_ip)
+            True
+        """
+        forwarded = request.headers.get("X-Forwarded-For")
+        if forwarded:
+            return forwarded.split(",")[0].strip()
+        return request.client.host if request.client else "unknown"
+
+    def check(self, request: Request) -> None:
+        """Check rate limit for the given request and raise HTTP 429 if exceeded.
+
+        Args:
+            request: FastAPI request object.
+
+        Raises:
+            HTTPException: 429 Too Many Requests when the rate limit is exceeded.
+
+        Examples:
+            >>> limiter = RateLimiter()
+            >>> callable(limiter.check)
+            True
+        """
+        client_ip = self._get_client_ip(request)
+        now = time.monotonic()
+
+        # Prune timestamps outside the current window
+        self._requests[client_ip] = [ts for ts in self._requests[client_ip] if now - ts < self.window_seconds]
+
+        if len(self._requests[client_ip]) >= self.max_requests:
+            raise HTTPException(
+                status_code=429,
+                detail="Too many requests. Please try again later.",
+                headers={"Retry-After": str(self.window_seconds)},
+            )
+
+        self._requests[client_ip].append(now)
+
+
+# Shared rate limiters for auth endpoints
+# - auth: tighter limit (login, register, password change)
+# - token: slightly more permissive (API token creation)
+auth_rate_limiter = RateLimiter(max_requests=10, window_seconds=60)
+token_rate_limiter = RateLimiter(max_requests=20, window_seconds=60)


### PR DESCRIPTION
## Summary
- Add in-memory sliding-window rate limiter utility (`mcpgateway/utils/rate_limit.py`) that tracks requests per client IP
- Apply rate limiting to login and registration endpoints (10 requests/minute) in `email_auth.py`
- Apply rate limiting to token creation endpoint (20 requests/minute) in `tokens.py`
- Returns HTTP 429 with `Retry-After` header when limit is exceeded

Closes F-19