### PR TITLE
fix: harden .gitignore to prevent secret and database file commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,11 @@ plugins_rust/Cargo.lock
 # crawler artifacts
 crawler_artifacts/
 crawled-data/
+
+# Agent runtime env files with secrets
+agent_runtimes/**/.env
+
+# Database files
+*.db-wal
+*.db-shm
+test_rootpath.db


### PR DESCRIPTION
## Summary
- Adds explicit `.gitignore` patterns for `agent_runtimes/**/.env`, `*.db-wal`, `*.db-shm`, and `test_rootpath.db` to prevent accidental commits of secrets and database state files
- The `.env.example` template with safe placeholder values already exists in `agent_runtimes/langchain_agent/`

## Required follow-up actions

**CRITICAL: The following secrets found in git history MUST be rotated immediately:**
- **OpenAI API key** (`sk-proj-...`) in `agent_runtimes/langchain_agent/.env`
- **Admin JWT bearer token** (`eyJhbGci...`) in `agent_runtimes/langchain_agent/.env`
- Any **Keycloak client secrets** that may have been committed

**Git history must be scrubbed** using [BFG Repo-Cleaner](https://rtyley.github.io/bfg-repo-cleaner/) to remove all traces of these secrets from the repository history. Simply removing files from tracking does not remove them from prior commits.

**A pre-commit secret scanner should be added** (e.g., [detect-secrets](https://github.com/Yelp/detect-secrets), [gitleaks](https://github.com/gitleaks/gitleaks), or [truffleHog](https://github.com/trufflesecurity/trufflehog)) to prevent future secret leaks at commit time.