### PR TITLE
feat(catalog): add Serper (Google Search) MCP server; fix tool URL fo…

### DIFF
--- a/mcp-catalog.yml
+++ b/mcp-catalog.yml
@@ -1547,7 +1547,6 @@ catalog_servers:
         required: true
         secret: true
         description: "Get one at https://serper.dev"
-        docs_url: "https://serper.dev"
     auth_type: "API Key"
     requires_api_key: true
     provider: "garylab / Serper.dev"

--- a/mcp-catalog.yml
+++ b/mcp-catalog.yml
@@ -1533,6 +1533,43 @@ catalog_servers:
     documentation_url: "https://github.com/exa-labs/exa-mcp-server"
     tools: ["web_search_exa", "web_fetch_exa", "web_search_advanced_exa"]
 
+  - id: serper-search
+    name: "Serper (Google Search)"
+    category: "Web Search"
+    url: ""
+    transport: "STDIO"
+    stdio_command: "uvx"
+    stdio_args: ["serper-mcp-server"]
+    stdio_timeout: 60
+    env_schema:
+      - key: SERPER_API_KEY
+        label: "Serper API Key"
+        required: true
+        secret: true
+        description: "Get one at https://serper.dev"
+        docs_url: "https://serper.dev"
+    auth_type: "API Key"
+    requires_api_key: true
+    provider: "garylab / Serper.dev"
+    description: "Google Search via the Serper API. Provides 13 tools: search, images, videos, news, places, maps, reviews, shopping, scholar, patents, lens, autocomplete, and webpage scraping. Runs as a local stdio MCP server (uvx); not yet installable from this catalog UI - use Add Gateway -> STDIO."
+    tags: ["web-search", "google", "serper", "stdio"]
+    logo_url: "https://img.logo.dev/serper.dev?token=pk_IQgnPY69T4mLXixm3ohN9A"
+    documentation_url: "https://github.com/garylab/serper-mcp-server"
+    tools:
+      - google_search
+      - google_search_images
+      - google_search_videos
+      - google_search_news
+      - google_search_places
+      - google_search_maps
+      - google_search_reviews
+      - google_search_shopping
+      - google_search_scholar
+      - google_search_patents
+      - google_search_lens
+      - google_search_autocomplete
+      - webpage_scrape
+
 # Categories for filtering
 categories:
   - Project Management

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -6847,11 +6847,19 @@ class CatalogServer(BaseModel):
     requires_api_key: bool = Field(default=False, description="Whether API key is required")
     secure: bool = Field(default=False, description="Whether additional security is required")
     tags: List[str] = Field(default_factory=list, description="Tags for categorization")
-    transport: Optional[str] = Field(None, description="Transport type: SSE, STREAMABLEHTTP, or WEBSOCKET")
+    transport: Optional[str] = Field(None, description="Transport type: SSE, STREAMABLEHTTP, STDIO, or WEBSOCKET")
     logo_url: Optional[str] = Field(None, description="URL to server logo/icon")
     documentation_url: Optional[str] = Field(None, description="URL to server documentation")
     tools: List[str] = Field(default_factory=list, description="List of tool names provided by this server")
     oauth_config: Optional[CatalogOAuthConfig] = Field(None, description="OAuth configuration details")
+    # STDIO catalog metadata (only set for transport=="STDIO" entries)
+    stdio_command: Optional[str] = Field(None, description="Executable command for STDIO connectors (e.g., uvx, npx)")
+    stdio_args: Optional[List[str]] = Field(None, description="Arguments for the STDIO command")
+    stdio_timeout: Optional[int] = Field(None, description="Startup timeout in seconds for the STDIO bridge")
+    env_schema: Optional[List[Dict[str, Any]]] = Field(
+        None,
+        description="Schema describing environment variables required by a STDIO connector (each entry: key, label, required, secret, description, docs_url)",
+    )
     is_registered: bool = Field(default=False, description="Whether server has at least one registered instance visible to the caller (computed from registered_instance_count)")
     registered_instance_count: int = Field(default=0, description="Number of registered gateway instances of this catalog entry visible to the caller")
     is_available: bool = Field(default=True, description="Whether server is currently available")

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1652,10 +1652,11 @@ class ToolService:
                                 headers = payload.headers.model_dump()
 
                     tool_call_result = ToolResult(content=[TextContent(text="", type="text")])
+                    upstream_url = tool.url or tool_gateway.url
                     if transport == "sse":
-                        tool_call_result = await connect_to_sse_server(tool_gateway.url, headers=headers)
+                        tool_call_result = await connect_to_sse_server(upstream_url, headers=headers)
                     elif transport == "streamablehttp":
-                        tool_call_result = await connect_to_streamablehttp_server(tool_gateway.url, headers=headers)
+                        tool_call_result = await connect_to_streamablehttp_server(upstream_url, headers=headers)
                     dump = tool_call_result.model_dump(by_alias=True)
                     logger.debug(f"Tool call result dump: {dump}")
                     content = dump.get("content", [])


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue
_No linked issue._

---

## 🚀 Summary

Adds **Serper (Google Search)** to the built-in MCP catalog and fixes a small URL-resolution bug in the tool invocation path.

- **Catalog**: new `serper-search` entry under the `Web Search` category. STDIO transport via `uvx serper-mcp-server`, requires `SERPER_API_KEY` (declared in `env_schema` as a required secret), exposes 13 Google tools (search, images, videos, news, places, maps, reviews, shopping, scholar, patents, lens, autocomplete, and webpage scrape).
- **Tool routing fix** (`mcpgateway/services/tool_service.py`): when a tool is invoked over `sse` or `streamablehttp`, the upstream URL is now resolved as `tool.url or tool_gateway.url`. Previously the gateway URL was always used, so per-tool URL overrides were silently ignored.

---

## 🧪 Checks

- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] CHANGELOG updated (if user-facing)

---

## 📓 Notes

The Serper entry is currently registered for visibility in the catalog UI but is not yet installable directly from the catalog — users add it via **Add Gateway → STDIO** (this is also called out in the entry's `description` field). Logo and docs URL point to `serper.dev` and `github.com/garylab/serper-mcp-server` respectively.

The `tool.url or tool_gateway.url` fallback preserves the existing behavior for tools that don't set their own URL, so this is a backwards-compatible fix.
